### PR TITLE
Rename package to gz-garden

### DIFF
--- a/debian/buster/debian/changelog
+++ b/debian/buster/debian/changelog
@@ -1,42 +1,5 @@
-ignition-garden (1.0.0-1~buster) buster; urgency=medium
+gz-garden (1.0.0-1~buster) buster; urgency=medium
 
-  * ignition-garden 1.0.0-1 release
+  * gz-garden 1.0.0-1 release
 
  -- Louise Poubel <louise@openrobotics.org>  Fri, 01 Oct 2021 15:10:49 -0700
-
-ignition-garden (1.0.0~pre1-5~buster) buster; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-5 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:54:15 -0700
-
-ignition-garden (1.0.0~pre1-4~buster) buster; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-4 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:45:59 -0700
-
-ignition-garden (1.0.0~pre1-3~buster) buster; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-3 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:40:34 -0700
-
-ignition-garden (1.0.0~pre1-2~buster) buster; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-2 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:35:11 -0700
-
-ignition-garden (1.0.0~pre1-1~buster) buster; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-1 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:18:30 -0700
-
-ignition-garden (0.999.999-1~buster) buster; urgency=medium
-
-  * placeholder
-
- -- Place Holder <placeholder@openrobotics.org>  Wed, 23 Sep 2020 16:44:44 -0700
-

--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -1,42 +1,5 @@
-ignition-garden (1.0.0-1~focal) focal; urgency=medium
+gz-garden (1.0.0-1~focal) focal; urgency=medium
 
-  * ignition-garden 1.0.0-1 release
+  * gz-garden 1.0.0-1 release
 
  -- Louise Poubel <louise@openrobotics.org>  Fri, 01 Oct 2021 15:10:49 -0700
-
-ignition-garden (1.0.0~pre1-5~focal) focal; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-5 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:54:15 -0700
-
-ignition-garden (1.0.0~pre1-4~focal) focal; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-4 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:45:59 -0700
-
-ignition-garden (1.0.0~pre1-3~focal) focal; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-3 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:40:34 -0700
-
-ignition-garden (1.0.0~pre1-2~focal) focal; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-2 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:35:11 -0700
-
-ignition-garden (1.0.0~pre1-1~focal) focal; urgency=medium
-
-  * ignition-garden 1.0.0~pre1-1 release
-
- -- Louise Poubel <louise@openrobotics.org>  Wed, 22 Sep 2021 17:10:46 -0700
-
-ignition-garden (0.999.999-1~focal) focal; urgency=medium
-
-  * Placeholder
-
- -- Place Holder <placeholder@openrobotics.org>  Wed, 23 Sep 2020 16:44:44 -0700
-

--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,6 @@
-ignition-garden (1.0.0-1~jammy) jammy; urgency=medium
+gz-garden (1.0.0-1~jammy) jammy; urgency=medium
 
-  * ignition-garden 1.0.0-1 release
+  * gz-garden 1.0.0-1 release
 
  -- Louise Poubel <louise@openrobotics.org>  Fri, 01 Oct 2021 15:10:49 -0700
 

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -1,4 +1,4 @@
-Source: ignition-garden
+Source: gz-garden
 Standards-Version: 3.9.5
 Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
 Section: science
@@ -22,11 +22,11 @@ Build-Depends: debhelper (>= 11),
                libignition-utils2-cli-dev,
                libignition-utils2-dev,
                libsdformat13-dev
-Vcs-Browser: https://github.com/ignition-release/ignition-garden-release
-Vcs-Git: https://github.com/ignition-release/ignition-garden-release
-Homepage: http://ignitionrobotics.org/
+Vcs-Browser: https://github.com/gazebo-release/gz-garden-release
+Vcs-Git: https://github.com/gazebo-release/gz-garden-release
+Homepage: http://gazebosim.org/
 
-Package: ignition-garden
+Package: gz-garden
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake3-dev,
@@ -51,6 +51,6 @@ Depends: libignition-cmake3-dev,
          python3-ignition-gazebo7,
          ${misc:Depends}
 Multi-Arch: foreign
-Description: Collection of ignition robotics packages - Garden
-  This is a metapackage used for triggering the whole collection of ignition
+Description: Collection of Gazebo packages - Garden
+  This is a metapackage used for triggering the whole collection of Gazebo
   packages corresponding to the Garden collection

--- a/ubuntu/debian/copyright
+++ b/ubuntu/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: ignition_cmake
+Upstream-Name: gazebo_garden
 Upstream-Contact: gazebo-list@gazebosim.org
-Source: https://bitbucket.org/osrf/ignition_cmake
+Source: https://github.com/gazebosim/gz-garden
 
 Files: *
 Copyright: 2013 Open Source Robotics Foundation


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/736

Test build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-garden-debbuilder&build=538)](https://build.osrfoundation.org/job/ign-garden-debbuilder/538/)

Now you can `sudo apt install gz-garden` 