### PR TITLE
Remove python bindings to avoid conflict with Citadel/Fortress

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -47,8 +47,6 @@ Depends: libgz-cmake3-dev,
          libgz-utils2-cli-dev,
          libgz-utils2-dev,
          libsdformat13-dev,
-         python3-gz-math7,
-         python3-gz-sim7,
          ${misc:Depends}
 Multi-Arch: foreign
 Description: Collection of Gazebo packages - Garden


### PR DESCRIPTION
The python binding files for gz-math in Citadel and Fortress conflict with those in Garden. As a short term fix, this PR removes the bindings so that `gz-fortress` and `gz-garden` can be installed side-by-side. 